### PR TITLE
Develop Upload Seller Image API, fix genre model struct

### DIFF
--- a/backend/app/app.go
+++ b/backend/app/app.go
@@ -28,8 +28,8 @@ func (a *App) InitializeApplication() {
 	a.DB = db
 	a.migrateSchemas()
 	a.setRouters()
-	// a.InsertImage()
-	// a.setupGenreCategories()
+	a.InsertImage()
+	a.setupGenreCategories()
 }
 
 func (a *App) InsertImage() {

--- a/backend/models/Images.go
+++ b/backend/models/Images.go
@@ -24,7 +24,7 @@ type ProductCatalogue struct {
 }
 
 type Genre struct {
-	ImageId   int `gorm:"primaryKey"`
+	ImageId   int
 	GenreType string
 }
 


### PR DESCRIPTION
Developed the `uploadSellerImage/` API. When the seller enters all the information such as title, description, price, genres and the image, this API is called to store all the relevant information, watermarked the uploaded image and store all the images in the cloud bucket