### PR TITLE
EmailProduct API: complete fetching metadata from paymentIntent Id

### DIFF
--- a/backend/app/app.go
+++ b/backend/app/app.go
@@ -99,6 +99,7 @@ func (a *App) setRouters() {
 	a.Router.HandleFunc("/addToCart", a.addToCart).Methods("POST")
 	a.Router.HandleFunc("/deleteFromCart", a.deleteFromCart).Methods("POST")
 	a.Router.HandleFunc("/checkoutAndProcessPayment", a.checkoutAndProcessPayment).Methods("POST")
+	a.Router.HandleFunc("/emailProduct", a.emailProduct).Methods("POST")
 }
 
 func (a *App) getAllImages(w http.ResponseWriter, r *http.Request) {
@@ -138,4 +139,8 @@ func (a *App) deleteFromCart(w http.ResponseWriter, r *http.Request) {
 
 func (a *App) checkoutAndProcessPayment(w http.ResponseWriter, r *http.Request) {
 	handler.CheckoutAndProcessPayment(a.DB, w, r)
+}
+
+func (a *App) emailProduct(w http.ResponseWriter, r *http.Request) {
+	handler.EmailProduct(a.DB, w, r)
 }


### PR DESCRIPTION
Completed Step 1 of `/emailProduct` API, fetching the payment intent data using the payment intent id that was sent from the front end when invoking this API.